### PR TITLE
Feature/add target groups and listener rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ git secrets --scan --cached --no-index --untracked
 Execute `deploy.sh` file
 
 ```
-./deploy.sh
+export ENV="dev"; ./deploy.sh
 ```

--- a/destroy.sh
+++ b/destroy.sh
@@ -2,6 +2,8 @@
 
 source setup-$ENV.sh
 
+rm -rf .terraform
+
 terraform init \
 	-backend=true \
 	-backend-config="bucket="$TF_VAR_backend_s3_bucket_name \
@@ -9,4 +11,4 @@ terraform init \
 	-backend-config="access_key="$AWS_ACCESS_KEY_ID \
 	-backend-config="secret_key="$AWS_SECRET_ACCESS_KEY
 
-terraform apply -var-file=env/$ENV-$AWS_DEFAULT_REGION.tfvars
+terraform destroy -var-file=env/$ENV-$AWS_DEFAULT_REGION.tfvars

--- a/env/prod-us-east-2.tfvars
+++ b/env/prod-us-east-2.tfvars
@@ -1,0 +1,5 @@
+# default AWS Tags
+default_aws_tags = {
+  Terraform = "true"
+  Environment = "prod"
+}

--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ resource "aws_alb_listener_rule" "ami_notifications_listener_rule" {
 # Creating the AMI Loadbalancer
 resource "aws_alb" "ami-if" {
   name            = "alb-ami-if"
-  subnets         = ["${data.terraform_remote_state.network.private_subnets}"]
+  subnets         = ["${data.terraform_remote_state.network.public_subnets}"]
   security_groups = ["${data.terraform_remote_state.network.default_security_group_id}","${data.terraform_remote_state.network.web_security_group_id}"]
   tags = "${var.default_aws_tags}"
 }


### PR DESCRIPTION
- modified the health check for all target groups
- Added listener rules
- Added destroy.sh
- Filled out prod-us-east-2.tfvars
- changed to use #!/bin/bash instead of sh because the source command didn't work on Ubuntu. This is because Ubuntu converts /bin/sh commands to use dash which does not contain source
- corrected to use the public subnets for the load balancer
- updated readme with correct deploy syntax